### PR TITLE
更换MinecraftWiki网址

### DIFF
--- a/MC百科实用链接.md
+++ b/MC百科实用链接.md
@@ -14,7 +14,7 @@ MCBBS
 https://www.mcbbs.net/
 
 Minecraft Wiki  
-https://minecraft.fandom.com/zh/wiki/Minecraft_Wiki
+https://zh.minecraft.wiki/
 
 背景制作  
 http://minecraft.novaskin.me/wallpapers


### PR DESCRIPTION
现在MinecraftWiki已经搬迁到了zh.minecraft.wiki，需要更换网址